### PR TITLE
Refactor update_version function in rust parser

### DIFF
--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -2,9 +2,10 @@ use std::fs;
 use anyhow::Error;
 use regex::Regex;
 
-pub fn update_version(version: String) {
+pub fn update_version(version: String) -> Result<(), Error>{
     update_cargo(&version)?;
     update_cargo_lock(&version)?;
+    Ok(())
 }
 
 fn get_project_name() -> Result<String, Error> {


### PR DESCRIPTION
The update_version function in the rust.rs file has been refactored to indicate output type now. This change will ensure that the function returns a Result, allowing for better error handling and function chaining. This change mainly affects the process of updating versions in cargo.lock.